### PR TITLE
memory leak fix and some other improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ src/%.o: src/%.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 test/%: test/%.c libsaneopt.a
-	$(CC) -L. -lsaneopt $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@ -L. -lsaneopt
 
 test: libsaneopt.a $(TESTS)
 	MallocScribble=1 test/test-saneopt

--- a/include/saneopt.h
+++ b/include/saneopt.h
@@ -1,9 +1,14 @@
 #ifndef _SANEOPT_H
 #define _SANEOPT_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 struct saneopt__alias {
-  char* option;
-  char* alias;
+  const char* option;
+  const char* alias;
 } typedef saneopt__alias_t;
 
 struct saneopt {
@@ -20,15 +25,20 @@ struct saneopt {
 saneopt_t* saneopt_init(int argc, char** argv);
 
 /*
+ * Release memory allocated by parser. 
+ */
+void saneopt_free(saneopt_t* opt);
+
+/*
  * Set an alias from `option` to `alias`.
  * Return -1 on error, 0 on success.
  */
-int saneopt_alias(saneopt_t* opt, char* option, char* alias);
+int saneopt_alias(saneopt_t* opt, const char* option, const char* alias);
 
 /*
  * Get option called `option`.
  */
-char* saneopt_get(saneopt_t* opt, char* option);
+const char* saneopt_get(saneopt_t* opt, const char* option);
 
 /*
  * Get all values for option called `option`.
@@ -43,7 +53,7 @@ char* saneopt_get(saneopt_t* opt, char* option);
  * If a occurrence is lacking a value (e.g. `--option --next-option`), it'll be
  * set to "".
  */
-char** saneopt_get_all(saneopt_t* opt, char* option);
+char** saneopt_get_all(saneopt_t* opt, const char* option);
 
 /*
  * Get command line arguments, that is: any arguments not being an argument
@@ -57,5 +67,9 @@ char** saneopt_get_all(saneopt_t* opt, char* option);
  * Will result in this function returning ["foo", "bar", "--not-option", "baz"].
  */
 char** saneopt_arguments(saneopt_t* opt);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/saneopt.c
+++ b/src/saneopt.c
@@ -13,7 +13,18 @@ saneopt_t* saneopt_init(int argc, char** argv) {
   return saneopt;
 }
 
-int saneopt__matches(saneopt_t* opt, char* option, char* arg) {
+void saneopt_free(saneopt_t* opt) {
+  int i;
+  if (opt->aliases) {
+    for (i = 0; opt->aliases && i < opt->alias_count; i++) {
+      free(opt->aliases[i]);
+    }
+    free(opt->aliases);
+  }
+  free(opt);
+}
+
+int saneopt__matches(saneopt_t* opt, const char* option, const char* arg) {
   int i;
 
   if (strncmp(arg, "--", 2) == 0) {
@@ -50,7 +61,7 @@ int saneopt__matches(saneopt_t* opt, char* option, char* arg) {
   return 0;
 }
 
-int saneopt_alias(saneopt_t* opt, char* option, char* alias) {
+int saneopt_alias(saneopt_t* opt, const char* option, const char* alias) {
   saneopt__alias_t** aliases;
   saneopt__alias_t* alias_ = malloc(sizeof(saneopt__alias_t));
 
@@ -71,7 +82,7 @@ int saneopt_alias(saneopt_t* opt, char* option, char* alias) {
   return 0;
 }
 
-char* saneopt_get(saneopt_t* opt, char* option) {
+const char* saneopt_get(saneopt_t* opt, const char* option) {
   int i;
   char* arg;
 
@@ -91,7 +102,7 @@ char* saneopt_get(saneopt_t* opt, char* option) {
   return NULL;
 }
 
-char** saneopt_get_all(saneopt_t* opt, char* option) {
+char** saneopt_get_all(saneopt_t* opt, const char* option) {
   int i;
   int count = 0;
   char* arg;

--- a/test/test-saneopt.c
+++ b/test/test-saneopt.c
@@ -13,7 +13,7 @@ void test_no_arg() {
   saneopt_t* opt = saneopt_init(0, argv);
   assert(saneopt_get(opt, "no-option") == NULL);
 
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_no_value() {
@@ -27,7 +27,7 @@ void test_no_value() {
   assert(strcmp(saneopt_get(opt, "option"), "") == 0);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_value() {
@@ -49,7 +49,7 @@ void test_value() {
   assert(strcmp(saneopt_get(opt, "k"), "short-value") == 0);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_long_alias() {
@@ -66,7 +66,7 @@ void test_long_alias() {
   assert(strcmp(saneopt_get(opt, "option"), "value") == 0);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_short_alias() {
@@ -82,7 +82,7 @@ void test_short_alias() {
   assert(strcmp(saneopt_get(opt, "option"), "value") == 0);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_stop_after_arguments() {
@@ -101,7 +101,7 @@ void test_stop_after_arguments() {
   assert(saneopt_get(opt, "next-option") == NULL);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_arguments() {
@@ -126,7 +126,7 @@ void test_arguments() {
   assert(args[3] == NULL);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_arguments_first() {
@@ -145,7 +145,7 @@ void test_arguments_first() {
   assert(args[2] == NULL);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_arguments_first_marker() {
@@ -165,7 +165,7 @@ void test_arguments_first_marker() {
   assert(args[2] == NULL);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_arguments_many_markers() {
@@ -195,7 +195,7 @@ void test_arguments_many_markers() {
   assert(args[6] == NULL);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 // https://github.com/mmalecki/saneopt/issues/2
@@ -220,7 +220,7 @@ void test_arguments_issue_2() {
   assert(args[2] == NULL);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 // https://github.com/mmalecki/saneopt/issues/3
@@ -247,7 +247,7 @@ void test_arguments_issue_3() {
   assert(args[3] == NULL);
 
   free(argv);
-  free(opt);
+  saneopt_free(opt);
 }
 
 void test_all() {
@@ -272,8 +272,8 @@ void test_all() {
   assert(args[3] == NULL);
 
   free(argv);
-  free(opt);
   free(args);
+  saneopt_free(opt);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
* fix memory leak in saneopt_alias() by adding saneopt_free()
* make libsaneopt.a linkable from C++ (extern "C" {} block)
* make args of saneopt_alias(), saneopt_get() and saneopt_get_all() immutable
* make return value of saneopt_get() immutable